### PR TITLE
Update rpc url evmos

### DIFF
--- a/_data/chains/eip155-9000.json
+++ b/_data/chains/eip155-9000.json
@@ -2,7 +2,7 @@
   "name": "Evmos Testnet",
   "chain": "Evmos",
   "network": "testnet",
-  "rpc": ["http://arsiamons.rpc.evmos.org:8545/"],
+  "rpc": ["https://ethereum.rpc.evmos.org"],
   "faucets": ["https://faucet.evmos.org"],
   "nativeCurrency": {
     "name": "Photon",


### PR DESCRIPTION
Change rpc url to: https://ethereum.rpc.evmos.org